### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "name": "lovata/oc-ordersshopaholic-plugin",
+    "type": "october-plugin",
+    "description": "Orders for Shopaholic plugin for October CMS",
+    "license": "GPL-3.0-only",
+    "require": {
+        "php": ">=7.0",
+        "lovata/oc-toolbox-plugin": "~1.17",
+        "lovata/oc-shopaholic-plugin": "~1.14"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,19 @@
     "type": "october-plugin",
     "description": "Orders for Shopaholic plugin for October CMS",
     "license": "GPL-3.0-only",
+    "repositories": [
+        {
+            "type": "git",
+            "url": "https://github.com/lovata/oc-toolbox-plugin.git"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/lovata/oc-shopaholic-plugin.git"
+        }
+    ],
     "require": {
         "php": ">=7.0",
-        "lovata/oc-toolbox-plugin": "~1.17",
-        "lovata/oc-shopaholic-plugin": "~1.14"
+        "lovata/oc-toolbox-plugin": "~1.20",
+        "lovata/oc-shopaholic-plugin": "~1.16"
     }
 }


### PR DESCRIPTION
Added composer.json for developer who mange packages by composer.

Though I added `repositories` section, it is just for reference. The composer.json of the main project has to have these repository definitions for composer to find the package successfully.
Or if this package is registered on packagist.org, the repository definition is not necessary.

thanks!